### PR TITLE
chore(deps): upgrade all GitHub Actions to latest stable

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -30,9 +30,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@4a8376e001c7725687f0624d1c3698a3f6ab337e
-        # v3 https://github.com/docker/login-action/commit/
-        # 9780b0c442fbb1117ed29e0efdff1e18412f7567
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -40,17 +38,13 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@deaa0dee567db6b95038c14152b037af85a8fe3b
-        # v5 https://github.com/docker/metadata-action/commit/
-        # 369eb591f429131d6889c46b94e711f089e6ca96
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
         id: push
-        uses: docker/build-push-action@c269a24fa28c26bf87ecef8c9ec22746dd962204
-        # v6 https://github.com/docker/build-push-action/commit/
-        # 48aba3b46d1b1fec4febb7c5d0c644b249a11355
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           push: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,7 +26,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.x'
       - run: pip install pip-audit && pip-audit -r requirements.txt || pip-audit


### PR DESCRIPTION
## Summary

Supersedes [PR #116](https://github.com/netresearch/ansible_role_client_base/pull/116) and resolves the underlying CI failure that was blocking it.

### Why #116 was stuck

#116 was approved but not merging. Two checks failed:

1. **Python Dependency Audit** — workflow uses `actions/setup-python@v6` (unpinned tag), which the org's "all actions must be pinned to a full-length commit SHA" policy rejects.
2. **auto-merge** — transient `504 Gateway Timeout` from GitHub during `gh pr merge --auto --rebase`. Would self-heal on rerun but was blocked by (1).

(1) is a real bug that affects every dependency PR, not just #116.

### What this PR does

**Past #116, straight to latest majors** — #116 only moved within the same major (still v3/v5/v6); we go to current stable v4/v6/v7:

| Action | From (current `main`) | To | Tag |
|---|---|---|---|
| `docker/login-action` | `4a8376e` | `4907a6d` | v4.1.0 |
| `docker/metadata-action` | `deaa0de` | `030e881` | v6.0.0 |
| `docker/build-push-action` | `c269a24` | `bcafcac` | v7.1.0 |

The v4/v6/v7 majors are coordinated releases that:
- Switch action runtime to Node 24 (needs Actions Runner v2.327.1+; GitHub-hosted runners are at v2.334+ already).
- Switch internal bundling from ncc to esbuild (ESM). No user-facing change.
- `build-push-action` v7 removed two deprecated envs (`DOCKER_BUILD_NO_SUMMARY`, `DOCKER_BUILD_EXPORT_RETENTION_DAYS`) — neither is used in this workflow.

**Fix the org policy violation** — pin `actions/setup-python@v6` -> `a309ff8...` (v6.2.0) in `security.yml`. This unblocks the Python Dependency Audit check that was failing on every dependency PR.

### Other dependencies audited, no change needed

| Action | Pinned SHA | Tag | Latest | Status |
|---|---|---|---|---|
| `actions/checkout` | `de0fac2` | v6.0.2 | v6.0.2 | already current |
| `actions/setup-python` (molecule.yml) | `a309ff8` | v6.2.0 | v6.2.0 | already current |
| `actions/cache` | `27d5ce7` | v5.0.5 | v5.0.5 | already current |
| `actions/attest-build-provenance` | `a2bbfa2` | v4.1.0 | v4.1.0 | already current |

`requirements.txt` left untouched — Ansible roles intentionally use loose requirements in CI to test against the latest packages each run; the only floor (`cryptography>=46.0.5`) is still well below the current 48.0.0 release and there's no reason to lift it.

## Test plan

- [ ] `Run Molecule Tests` passes (uses pinned `setup-python` and `cache`)
- [ ] `Lint Ansible Role` passes (yamllint + ansible-lint)
- [ ] `Build image` job in `ghcr.yml` succeeds with the bumped Docker actions
- [ ] `Python Dependency Audit` runs — was failing on every PR due to unpinned `@v6`; should now pass (or surface real audit findings)
- [ ] `dependency-review / Dependency Review` passes
- [ ] `gitleaks / Secret Scanning` passes

Once green, this PR replaces #116 (close it after merge).