### PR TITLE
docs: add LICENSE, fix README bugs, add CI badges

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2024-present, Netresearch DTT GmbH and contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -44,10 +44,15 @@ Ansible >= 2.16.0
 You can apply the Ansible role directly on the target machine by running the playbook locally. Ensure that the target machine is accessible and the necessary dependencies are installed on the local machine.
 
 #### Prerequisites:
-- Install Git and Ansible on your local machine.
+- Install Git and Ansible on your local machine. On modern Ubuntu (24.04+),
+  installing Python packages globally is blocked by [PEP 668](https://peps.python.org/pep-0668/),
+  so install Ansible inside a virtual environment:
     ```bash
-    sudo apt install git python3-pip
-    pip install ansible
+    sudo apt install git python3-venv
+    python3 -m venv ~/ansible-env
+    source ~/ansible-env/bin/activate
+    pip install --upgrade pip
+    pip install 'ansible>=2.16'
     ```
 
 #### Steps:
@@ -70,10 +75,14 @@ You can apply the Ansible role directly on the target machine by running the pla
 ### 2. Apply the Role Remotely via SSH
 
 #### Prerequisites:
-- Ansible, git and sshpass installed on your local machine.
+- Ansible, git and sshpass installed on your local machine. As above,
+  install Ansible inside a virtual environment to avoid PEP 668:
     ```bash
-    sudo apt install git sshpass python3 python3-pip
-    pip install ansible
+    sudo apt install git sshpass python3-venv
+    python3 -m venv ~/ansible-env
+    source ~/ansible-env/bin/activate
+    pip install --upgrade pip
+    pip install 'ansible>=2.16'
     ```
 
 - **SSH server installed and configured on the target Ubuntu machine**:  
@@ -277,9 +286,9 @@ A curated list of essential software for Ubuntu, categorized into **General Tool
    **Relevance**: A must-have for developers working with remote servers.
 
 6. **`docker`**  
-   **Description:** Platform for developing, deploying, and managing containerized applications.  
-   **Relevance:** Crucial for developers working with microservices or containerized environments.  
-   **Note:** This role does not install Docker. It is recommended to use the [geerlingguy.docker](https://github.com/geerlingguy/ansible-role-docker) role to install Docker.
+   **Description**: Platform for developing, deploying, and managing containerized applications.  
+   **Relevance**: Crucial for developers working with microservices or containerized environments.  
+   **Note**: This role does not install Docker. It is recommended to use the [geerlingguy.docker](https://github.com/geerlingguy/ansible-role-docker) role to install Docker.
 
 7. **`wireguard`**  
    **Description**: A modern, fast, and secure VPN protocol.  

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Client-Base Ansible Role
 
+[![Molecule Tests and Linting](https://github.com/netresearch/ansible_role_client_base/actions/workflows/molecule.yml/badge.svg?branch=main)](https://github.com/netresearch/ansible_role_client_base/actions/workflows/molecule.yml)
+[![Build container image](https://github.com/netresearch/ansible_role_client_base/actions/workflows/ghcr.yml/badge.svg?branch=main)](https://github.com/netresearch/ansible_role_client_base/actions/workflows/ghcr.yml)
+[![Security](https://github.com/netresearch/ansible_role_client_base/actions/workflows/security.yml/badge.svg?branch=main)](https://github.com/netresearch/ansible_role_client_base/actions/workflows/security.yml)
+[![License: BSD-3-Clause](https://img.shields.io/badge/License-BSD--3--Clause-blue.svg)](LICENSE)
+
 This Ansible role provides a basic setup for Linux based clients.
 
 Currently supported platforms:
@@ -41,14 +46,15 @@ You can apply the Ansible role directly on the target machine by running the pla
 #### Prerequisites:
 - Install Git and Ansible on your local machine.
     ```bash
-    pip install git ansible
+    sudo apt install git python3-pip
+    pip install ansible
     ```
 
 #### Steps:
-1. Clone `ansible_role_client_base` - Gitlab token required
+1. Clone `ansible_role_client_base`
     ```bash
     cd ~
-    git clone https://git.netresearch.de/provision/ansible_role_client_base.git
+    git clone https://github.com/netresearch/ansible_role_client_base.git
     ```
 
 2. Navigate to the root of the project:
@@ -66,8 +72,8 @@ You can apply the Ansible role directly on the target machine by running the pla
 #### Prerequisites:
 - Ansible, git and sshpass installed on your local machine.
     ```bash
-    sudo apt install sshpass python3
-    pip install ansible git
+    sudo apt install git sshpass python3 python3-pip
+    pip install ansible
     ```
 
 - **SSH server installed and configured on the target Ubuntu machine**:  
@@ -271,10 +277,14 @@ A curated list of essential software for Ubuntu, categorized into **General Tool
    **Relevance**: A must-have for developers working with remote servers.
 
 6. **`docker`**  
- **Description:** Platform for developing, deploying, and managing containerized applications.  
-  **Relevance:** Crucial for developers working with microservices or containerized environments.  
-  **Note:** This role does not install Docker. It is recommended to use the [geerlingguy.docker](https://github.com/geerlingguy/ansible-role-docker) role to install Docker.
+   **Description:** Platform for developing, deploying, and managing containerized applications.  
+   **Relevance:** Crucial for developers working with microservices or containerized environments.  
+   **Note:** This role does not install Docker. It is recommended to use the [geerlingguy.docker](https://github.com/geerlingguy/ansible-role-docker) role to install Docker.
 
-8. **`wireguard`**  
+7. **`wireguard`**  
    **Description**: A modern, fast, and secure VPN protocol.  
    **Relevance**: Useful for developers needing secure remote access or networking.
+
+## License
+
+[BSD-3-Clause](LICENSE) — Copyright (c) 2024-present, Netresearch DTT GmbH and contributors.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: >
     This Ansible role provides a base setup for Linux based client operating
     systems.
-  license: BSD
+  license: BSD-3-Clause
   min_ansible_version: "2.16.0"
   platforms:
     - name: Ubuntu


### PR DESCRIPTION
## Summary

- **LICENSE** — repo had no LICENSE file. `meta/main.yml` declared `license: BSD` (ambiguous: BSD-2 vs BSD-3). Adds the BSD-3-Clause text with copyright "Netresearch DTT GmbH and contributors", 2024-present.
- **meta/main.yml** — `license: BSD` -> `license: BSD-3-Clause` (SPDX identifier so Galaxy and scanners resolve it unambiguously).
- **README.md** — three real bugs + cosmetic cleanup, plus badges and a License section.

## Bug fixes in README

| Line(s) | Problem | Fix |
|---|---|---|
| `pip install git ansible` (twice) | `git` is not a Python package; this command fails | install `git` via apt, `ansible` via pip |
| `git clone https://git.netresearch.de/provision/ansible_role_client_base.git` | Stale internal URL — repo is public on GitHub now and the GitLab path is no longer reachable for external users | use `https://github.com/netresearch/ansible_role_client_base.git` |
| Developer Tools list numbered `5, 6, 8, 8` | The two `8`s broke the list; the `docker` entry's continuation lines were also under-indented | renumber to `5, 6, 7`; align indentation |

## Additions

- Top-of-README CI badges: `Molecule Tests and Linting`, `Build container image`, `Security`, License.
- License section at the bottom.

## Test plan

- [ ] yamllint passes on `meta/main.yml` (already verified locally)
- [ ] Molecule tests still pass (no role logic changed)
- [ ] CI badges render on GitHub
- [ ] LICENSE detected by GitHub's license API (file should appear in repo "About" sidebar after merge)