### PR TITLE
chore(ci): route molecule/lint/audit jobs through shared reusables

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -9,51 +9,33 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
+  # molecule test + ansible-lint + yamllint run through the org's shared
+  # reusable workflows in netresearch/.github, so the pinned action versions
+  # (checkout, setup-python) are maintained centrally instead of per-repo.
   molecule:
     name: Run Molecule Tests
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-      - name: Free disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
-          df -h
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-        with:
-          python-version: '3.x'
-          cache: pip
-      - name: Cache pip dependencies
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-      - run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install -r requirements.txt
-      - run: ansible-playbook molecule/default/prepare.yml --syntax-check
-      - run: molecule test
+    uses: netresearch/.github/.github/workflows/ansible-molecule.yml@main
+    permissions:
+      contents: read
+    with:
+      runs-on: ubuntu-24.04
+      pip-packages: "-r requirements.txt"
+      command: test
 
   lint:
     name: Lint Ansible Role
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-        with:
-          python-version: '3.x'
-          cache: pip
-      - name: Cache pip dependencies
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-      - run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install -r requirements.txt
-      - run: yamllint .
-      - run: ansible-lint .
+    uses: netresearch/.github/.github/workflows/ansible-lint.yml@main
+    permissions:
+      contents: read
+    with:
+      runs-on: ubuntu-24.04
+      pip-packages: "-r requirements.txt"
+
+  yaml-lint:
+    name: Lint YAML
+    uses: netresearch/.github/.github/workflows/lint-yaml.yml@main
+    permissions:
+      contents: read

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,14 +19,14 @@ jobs:
       contents: read
       pull-requests: write
 
-  pip-audit:
-    name: Python Dependency Audit
-    runs-on: ubuntu-latest
+  # pip-audit via the shared python-audit.yml reusable (pip). run-bandit is
+  # off to preserve the previous scope (pip-audit only); enable bandit
+  # separately once its findings are triaged.
+  audit:
+    uses: netresearch/.github/.github/workflows/python-audit.yml@main
     permissions:
       contents: read
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-        with:
-          python-version: '3.x'
-      - run: pip install pip-audit && pip-audit -r requirements.txt || pip-audit
+    with:
+      package-manager: pip
+      python-version: "3.x"
+      run-bandit: false

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -13,7 +13,6 @@ platforms:
     image: geerlingguy/docker-ubuntu2404-ansible:latest
     privileged: true
     pre_build_image: true
-    cgroupns: host
     cgroupns_mode: host
     command: /lib/systemd/systemd
     volumes:
@@ -22,7 +21,6 @@ platforms:
     image: geerlingguy/docker-ubuntu2404-ansible:latest
     privileged: true
     pre_build_image: true
-    cgroupns: host
     cgroupns_mode: host
     command: /lib/systemd/systemd
     volumes:


### PR DESCRIPTION
## What

Routes the CI jobs through the org's shared reusables in `netresearch/.github` (found via an org-wide sweep for the inline-`setup-python` pattern), so the pinned action versions are maintained centrally instead of per-repo:

- **molecule.yml**: `molecule` → **`ansible-molecule.yml`** (`pip-packages: -r requirements.txt`, `command: test`); `lint` → **`ansible-lint.yml`**; plus a `yaml-lint` job via **`lint-yaml.yml`** (preserves the standalone `yamllint .`, reads the repo `.yamllint.yml`).
- **security.yml**: inline `pip-audit` → **`python-audit.yml`** (`package-manager: pip`, `run-bandit: false` to preserve the pip-audit-only scope). `gitleaks` + `dependency-review` already used shared reusables.

Drops two now-redundant steps from the molecule job: the standalone `ansible-playbook … --syntax-check` (`molecule test` converges `prepare.yml` anyway) and the manual free-disk-space cleanup (revisit only if the docker run needs it — CI will tell).

## Branch protection

The reusable-backed jobs report as `<job> / <reusable-job>`, so the required status-check names change. The required checks are updated in lockstep with this PR:

- `Run Molecule Tests` → `Run Molecule Tests / molecule test`
- `Lint Ansible Role` → `Lint Ansible Role / ansible-lint`

## Verification

Local `actionlint` + `yamllint` clean.
