### PR TITLE
ci(ghcr): route container build and attestation through shared reusables

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -12,50 +12,63 @@ on:
     branches:
       - 'main'
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+permissions: {}
 
 jobs:
-  build-and-push-image:
+  # The container build runs through the org's shared bake reusable, so the
+  # pinned action versions (checkout, buildx, metadata, login, bake) are
+  # maintained centrally in netresearch/.github instead of per-repo. The tag
+  # scheme still comes from docker/metadata-action — `metadata-images` makes
+  # the reusable run it and feed its generated tag/label bake files into the
+  # `docker-metadata-action` stub target of docker-bake.hcl.
+  build:
     name: Build image
-    runs-on: ubuntu-latest
+    uses: netresearch/.github/.github/workflows/build-container-bake.yml@main
     permissions:
       contents: read
       packages: write
-      attestations: write
+      security-events: write
       id-token: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+    with:
+      targets: app
+      # REQUIRED whenever metadata-images is used: docker/bake-action would
+      # otherwise build from the git remote context, where metadata-action's
+      # $RUNNER_TEMP tag/label bake files do not exist.
+      bake-source: "."
+      push: ${{ github.event_name != 'pull_request' }}
+      metadata-images: ghcr.io/${{ github.repository }}
+      # docker/metadata-action's four default tag rules written out verbatim
+      # (an explicit list disables the implicit default), plus the
+      # unconditional `latest` the previous build-push-action step appended
+      # by hand.
+      metadata-tags: |
+        type=schedule
+        type=ref,event=branch
+        type=ref,event=tag
+        type=ref,event=pr
+        type=raw,value=latest
+      # This workflow has no `schedule` trigger, so workflow_dispatch is the
+      # only way to force a refresh of the `devture/ansible:latest` base
+      # image and its OS packages. With cache-from that run would restore the
+      # previous layer chain and rebuild nothing, so the cache is disabled
+      # for manual runs and used for push/PR runs.
+      cache: ${{ github.event_name != 'workflow_dispatch' }}
 
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-      - name: Build and push Docker image
-        id: push
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: .
-          push: true
-          tags: |
-            ${{ steps.meta.outputs.tags }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-          labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
-        with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true
+  # GitHub-issued, Sigstore-signed SLSA build provenance — the successor of
+  # the removed actions/attest-build-provenance step. It lives in its own
+  # reusable because `attestations: write` must not be forced on every bake
+  # caller. Skipped on pull_request, where nothing is pushed and there is
+  # therefore no digest to attest.
+  attest:
+    name: Attest image provenance
+    needs: build
+    if: ${{ github.event_name != 'pull_request' }}
+    uses: netresearch/.github/.github/workflows/attest-image.yml@main
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    with:
+      bake-metadata: ${{ needs.build.outputs.bake-metadata }}
+      push-to-registry: true

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,32 @@
+# Bake definition for the ansible_role_client_base container image.
+#
+# Tags and labels are deliberately NOT declared here. CI runs
+# docker/metadata-action (through the `metadata-images` / `metadata-tags`
+# inputs of netresearch/.github build-container-bake.yml) and appends the
+# tag + label bake files it generates, which populate the
+# `docker-metadata-action` stub target below. `app` inherits that target and
+# therefore picks up the whole tag fan-out plus the OCI labels.
+#
+# Never add `tags` to `app`: a target's own `tags` replaces the inherited
+# ones, which would silently drop the metadata-action tag scheme.
+#
+# The generated tag/label bake files live in $RUNNER_TEMP, i.e. in the local
+# checkout — which is why the workflow passes `bake-source: "."`. Without it
+# docker/bake-action defaults to the git remote context and cannot see them.
+#
+# Local use (no metadata-action, so the image stays untagged):
+#   docker buildx bake --print
+#   docker buildx bake app
+
+# Populated at build time by docker/metadata-action's generated bake files.
+target "docker-metadata-action" {}
+
+target "app" {
+  inherits   = ["docker-metadata-action"]
+  context    = "."
+  dockerfile = "Dockerfile"
+}
+
+group "default" {
+  targets = ["app"]
+}


### PR DESCRIPTION
Migrates `ghcr.yml` to **zero step-level actions**: every job is now a call to a shared reusable workflow in [netresearch/.github](https://github.com/netresearch/.github). Container builds are bake-only per org policy, so the build goes through `build-container-bake.yml` and a new `docker-bake.hcl`.

The GitHub-issued SLSA provenance attestation is preserved by the new [`attest-image.yml`](https://github.com/netresearch/.github/blob/main/.github/workflows/attest-image.yml) reusable — an earlier attempt at this migration was correctly blocked because bake alone would have destroyed it. `build-container-bake`'s `attest:` input is *not* equivalent: that is buildx in-image `provenance=mode=max`, not a Sigstore-signed, `gh attestation verify`-able GitHub attestation.

## Before / after

| Aspect | Before (5 step-level actions) | After (2 reusable calls) |
| --- | --- | --- |
| Checkout / login / buildx | `actions/checkout`, `docker/login-action` steps | inside `build-container-bake.yml` |
| Tag + label scheme | `docker/metadata-action` (implicit defaults) + hardcoded `:latest` | same action, run by the reusable via `metadata-images` / `metadata-tags`; defaults written out verbatim + `type=raw,value=latest` |
| Image name | `ghcr.io/${{ github.repository }}` | `ghcr.io/${{ github.repository }}` (unchanged) |
| Build | `docker/build-push-action` (`context: .`) | `docker/bake-action` on `docker-bake.hcl` target `app` (`context = "."`, same `Dockerfile`) |
| Provenance attestation | `actions/attest-build-provenance` step, `push-to-registry: true` | `attest-image.yml` job, `push-to-registry: true` — same action, same subject (image name without tag), same pushed digest |
| Attestation permissions | forced on the build job | isolated in the `attest` job (`id-token: write`, `attestations: write`) |
| Platforms | buildx default (runner-native) | unchanged — `platforms` deliberately absent from the bake file |

### Tag list, preserved verbatim

The old workflow passed no `tags:` to `docker/metadata-action`, so it used the action's four built-in defaults, and then appended `:latest` by hand in `build-push-action`. Since an explicit list disables the implicit default, the four defaults are now spelled out plus `latest`:

```
type=schedule
type=ref,event=branch
type=ref,event=tag
type=ref,event=pr
type=raw,value=latest
```

These are exactly the defaults in [`metadata-action@v6.2.0 src/tag.ts`](https://github.com/docker/metadata-action/blob/v6.2.0/src/tag.ts#L54-L64). On a `v*` tag push `flavor: latest=auto` also emits `latest`; `docker buildx bake` de-duplicates the resulting tag list (verified, see below).

### Why `bake-source: "."`

`docker/bake-action` with no `source:` builds from the **git remote** context (`<repo>.git#<ref>`) and reads `files:` from that remote tree. `docker/metadata-action` writes its tag/label bake files into `$RUNNER_TEMP` on the runner, which does not exist there — the build then dies with `cannot parse bake definitions: ... docker-metadata-action-bake-tags.json: no such file or directory`. `bake-source: "."` is mandatory whenever `metadata-images` is used.

## Intentionally changed

1. **`pull_request` runs no longer push.** `push: ${{ github.event_name != 'pull_request' }}`. Previously `push: true` was unconditional, so every PR build published to GHCR *and overwrote `:latest`* with unreviewed code. The `attest` job carries the same condition, since a non-pushed build has no digest to attest.
2. **Trivy scan of the pushed image + SARIF upload** — the reusable's default (`scan: true`). Code scanning is already enabled on this repo, so the upload works. Findings are report-only and do not fail the build.
3. **GHA layer cache enabled, except on `workflow_dispatch`.** There was no build cache before. This workflow has no `schedule` trigger, so a manual dispatch is the only way to force a refresh of the `devture/ansible:latest` base image and its OS packages — with `cache-from` such a run restores the old layer chain and rebuilds nothing, turning a security refresh into a no-op. Hence `cache: ${{ github.event_name != 'workflow_dispatch' }}`.
4. **`REGISTRY` / `IMAGE_NAME` `env:` block removed** — the `env` context is not available in a reusable call's `with:`; the values are inlined and identical.
5. **`docker-bake.hcl` is now part of the image**, because the `Dockerfile` does `COPY ./ /ansible_role_client_base/` and the repo has no `.dockerignore`. One extra file, no functional effect.
6. Cosign signing is **not** enabled (`sign:` left at its `false` default) — nothing signed images before and `sign: true` would be keyless OIDC, a different guarantee.

## Verification performed

- `actionlint 1.7.12` over all workflows in the repo: clean, exit 0.
- `docker buildx bake -f docker-bake.hcl app --print` — resolves to a single `app` target, no tags (correct: tags only exist when metadata-action ran).
- Same print with simulated `docker-metadata-action` tag **and** label bake files (the exact JSON shape `metadata-action` writes, deliberately containing a duplicate `latest`): `app` inherits `tags`, `labels` and `args` from the stub target, and buildx collapses the duplicate `latest` into one. This proves the inheritance and rules out duplicate-tag breakage on `v*` tag pushes.
- `docker buildx bake -f docker-bake.hcl app --set '*.output=type=cacheonly'` — real build against the current `Dockerfile`, exit 0.
- Both reusables were read in full from `netresearch/.github@main`; every input used (`targets`, `bake-source`, `push`, `metadata-images`, `metadata-tags`, `cache`, `bake-metadata`, `push-to-registry`) exists there, and the calling jobs grant the full union of each called workflow's job permissions (validated statically at startup, before any `if:`).

Not verified here: no live GHCR push or attestation was executed — that first happens on merge to `main`. After the first run, provenance can be checked with `gh attestation verify oci://ghcr.io/netresearch/ansible_role_client_base@<digest> --owner netresearch`.
